### PR TITLE
Ensure token store exposes expiration helper

### DIFF
--- a/frontend/src/api/tokenStore.js
+++ b/frontend/src/api/tokenStore.js
@@ -11,7 +11,8 @@ export async function getTokens() {
   return memory;
 }
 
-export async function setTokens(tokens) {
+// Persist the latest auth tokens. Pass `null` to clear.
+export async function saveTokens(tokens) {
   memory = tokens || null;
   if (tokens) {
     await AsyncStorage.setItem(KEY, JSON.stringify(tokens));
@@ -25,7 +26,16 @@ export async function clearTokens() {
   await AsyncStorage.removeItem(KEY);
 }
 
+// Determine whether the current access token is expired or close to expiring.
+// If `expiresAt` is falsy, assume the token does not expire.
+export function isAccessTokenExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const exp = typeof expiresAt === 'number' ? expiresAt : new Date(expiresAt).getTime();
+  // Refresh a minute early to avoid edge cases with clock skew
+  return Date.now() >= exp - 60 * 1000;
+}
+
 // Also export a default object so either import style works:
 //   import { getTokens } from './tokenStore'
 //   import tokenStore from './tokenStore'; tokenStore.getTokens()
-export default { getTokens, setTokens, clearTokens };
+export default { getTokens, saveTokens, clearTokens, isAccessTokenExpired };


### PR DESCRIPTION
## Summary
- rename `setTokens` to `saveTokens` for consistent API
- add `isAccessTokenExpired` helper and export it (default and named)

## Testing
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5f0f3152c83339ea6359e9e57a75a