### PR TITLE
feat: log requests with sanitization

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -9,9 +9,9 @@ package-lock.json
 .env
 
 # Logs
-logs
-*.log
 logs/*
+!logs/.gitkeep
+*.log
 *.pid
 *.seed
 *.pid.lock


### PR DESCRIPTION
## Summary
- add server-side request/response logging with optional verbose mode
- sanitize sensitive data before writing logs
- track logs directory via gitkeep

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b60ff74ce083338095dd7123c68eba