### PR TITLE
Add post creation flow and fix post listing

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -8,6 +8,8 @@ import LoginScreen from './src/screens/LoginScreen';
 import SignupScreen from './src/screens/SignupScreen';
 import HomeScreen from './src/screens/HomeScreen';
 import FeedScreen from './src/screens/FeedScreen';
+import CreatePostScreen from './src/screens/CreatePostScreen';
+import PostDetailScreen from './src/screens/PostDetailScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -23,6 +25,8 @@ function Root() {
           // Logged-in stack
           <>
             <Stack.Screen name="Home" component={FeedScreen} />
+            <Stack.Screen name="CreatePost" component={CreatePostScreen} />
+            <Stack.Screen name="PostDetail" component={PostDetailScreen} />
           </>
         ) : (
           // Auth stack

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -21,10 +21,18 @@ const qs = (params = {}) => {
 };
 
 // ---------- Posts ----------
-export const listPosts  = (params = {}) => apiGet(`/posts${qs(params)}`);
+export const listPosts  = async (params = {}) => {
+  const data = await apiGet(`/posts${qs(params)}`);
+  data.posts = (data.posts || []).map(p => ({
+    ...p,
+    likes: p.likesCount,
+    liked: p.likedByMe,
+  }));
+  return data;
+};
 export const getPost    = (id) => apiGet(`/posts/${id}`);
 export const createPost = (title, content, lat, lng, files = []) =>
-  apiUploadPost('/posts', { title, content, lat, lng, files });
+  apiUploadPost({ title, content, lat, lng, files });
 export const addComment = (id, text) => apiPost(`/posts/${id}/comments`, { text });
 export const likePost   = (id) => apiPost(`/posts/${id}/like`, {});
 export const unlikePost = (id) => apiDelete(`/posts/${id}/like`, {});

--- a/frontend/src/screens/CreatePostScreen.js
+++ b/frontend/src/screens/CreatePostScreen.js
@@ -1,1 +1,53 @@
-import React from 'react'; export default function CreatePostScreen(){ return null }
+import React, { useState } from 'react';
+import { Image, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { createPost } from '../api';
+import Screen from '../ui/Screen';
+import Field from '../ui/Field';
+import Button from '../ui/Button';
+
+export default function CreatePostScreen({ navigation }) {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [image, setImage] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      const asset = result.assets[0];
+      setImage({
+        uri: asset.uri,
+        name: asset.fileName || 'photo.jpg',
+        type: asset.mimeType || 'image/jpeg',
+      });
+    }
+  };
+
+  const submit = async () => {
+    try {
+      setLoading(true);
+      await createPost(title, content, undefined, undefined, image ? [image] : []);
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert('Error', e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Screen>
+      <Field label="Title" value={title} onChangeText={setTitle} placeholder="What's happening?" />
+      <Field label="Content" value={content} onChangeText={setContent} placeholder="Add more details" multiline />
+      {image ? (
+        <Image source={{ uri: image.uri }} style={{ width: '100%', height: 200, marginBottom: 12, borderRadius: 8 }} />
+      ) : null}
+      <Button title="Add Photo" onPress={pickImage} style={{ marginBottom: 12 }} />
+      <Button title="Post" onPress={submit} loading={loading} />
+    </Screen>
+  );
+}


### PR DESCRIPTION
## Summary
- map backend post fields to frontend expectations and correct createPost API call
- add full create post screen with image upload
- register create post and detail screens in navigation

## Testing
- `cd frontend && npm test`
- `cd ../backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b613615e1c833388a03600a7a60a00