### PR TITLE
Fix createPost upload path

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -32,7 +32,7 @@ export const listPosts  = async (params = {}) => {
 };
 export const getPost    = (id) => apiGet(`/posts/${id}`);
 export const createPost = (title, content, lat, lng, files = []) =>
-  apiUploadPost({ title, content, lat, lng, files });
+  apiUploadPost('/posts', { title, content, lat, lng, files });
 export const addComment = (id, text) => apiPost(`/posts/${id}/comments`, { text });
 export const likePost   = (id) => apiPost(`/posts/${id}/like`, {});
 export const unlikePost = (id) => apiDelete(`/posts/${id}/like`, {});


### PR DESCRIPTION
## Summary
- Correct post creation helper to send multipart uploads to `/posts`

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` (backend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b615fc9cd48333a9177aeae99f9ef0