### PR TITLE
feat: redesign create post page and fix blank screen

### DIFF
--- a/frontend/src/screens/CreatePostScreen.js
+++ b/frontend/src/screens/CreatePostScreen.js
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
-import { Image, Alert } from 'react-native';
+import {
+  Image,
+  Alert,
+  View,
+  Text,
+  TouchableOpacity,
+} from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { createPost } from '../api';
 import Screen from '../ui/Screen';
 import Field from '../ui/Field';
 import Button from '../ui/Button';
+import Card from '../ui/Card';
+import { theme } from '../theme';
 
 export default function CreatePostScreen({ navigation }) {
-  const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [image, setImage] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -30,7 +37,7 @@ export default function CreatePostScreen({ navigation }) {
   const submit = async () => {
     try {
       setLoading(true);
-      await createPost(title, content, undefined, undefined, image ? [image] : []);
+      await createPost('Untitled', content, undefined, undefined, image ? [image] : []);
       navigation.goBack();
     } catch (e) {
       Alert.alert('Error', e.message || String(e));
@@ -41,13 +48,58 @@ export default function CreatePostScreen({ navigation }) {
 
   return (
     <Screen>
-      <Field label="Title" value={title} onChangeText={setTitle} placeholder="What's happening?" />
-      <Field label="Content" value={content} onChangeText={setContent} placeholder="Add more details" multiline />
-      {image ? (
-        <Image source={{ uri: image.uri }} style={{ width: '100%', height: 200, marginBottom: 12, borderRadius: 8 }} />
-      ) : null}
-      <Button title="Add Photo" onPress={pickImage} style={{ marginBottom: 12 }} />
-      <Button title="Post" onPress={submit} loading={loading} />
+      <Card style={{ marginBottom: 16 }}>
+        <Field
+          label={null}
+          value={content}
+          onChangeText={setContent}
+          placeholder="What's on your mind, neighbor?"
+          multiline
+        />
+        {image ? (
+          <Image
+            source={{ uri: image.uri }}
+            style={{ width: '100%', height: 200, marginBottom: 12, borderRadius: 8 }}
+          />
+        ) : null}
+        <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+          <Button
+            title="Add Photo"
+            onPress={pickImage}
+            style={{ flex: 1, marginRight: 8 }}
+          />
+          <Button
+            title="Post"
+            onPress={submit}
+            loading={loading}
+            style={{ flex: 1 }}
+          />
+        </View>
+      </Card>
+
+      <Card>
+        <Text style={{ fontWeight: '600', marginBottom: 8 }}>Create something</Text>
+        {[
+          'Share an update',
+          'Sell an item',
+          'Request advice',
+          'Post a missing pet',
+          'Poll your neighbors',
+        ].map((label) => (
+          <Option key={label} label={label} />
+        ))}
+      </Card>
     </Screen>
+  );
+}
+
+function Option({ label, onPress }) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{ paddingVertical: theme.spacing(1) }}
+    >
+      <Text style={{ color: theme.colors.text }}>{label}</Text>
+    </TouchableOpacity>
   );
 }

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,17 +1,30 @@
 // src/theme.js
 export const theme = {
-    colors: {
-      bg: '#F7F8FA',
-      card: '#FFFFFF',
-      text: '#111827',
-      sub: '#6B7280',
-      border: '#E5E7EB',
-      primary: '#16A34A', // Nextdoor-ish green
-      chip: '#EFF6FF',
-    },
-    radius: 14,
-    pad: 14,
-  };
-  
-export const navTheme={dark:false,colors:{primary:theme.colors.primary,background:theme.colors.background,card:theme.colors.card,text:theme.colors.text,border:theme.colors.border,notification:theme.colors.accent}};
+  colors: {
+    bg: '#F7F8FA',
+    background: '#F7F8FA',
+    card: '#FFFFFF',
+    text: '#111827',
+    sub: '#6B7280',
+    muted: '#6B7280',
+    border: '#E5E7EB',
+    primary: '#16A34A', // Nextdoor-ish green
+    chip: '#EFF6FF',
+  },
+  radius: 14,
+  pad: 14,
+  spacing: (n) => n * 8,
+};
+
+export const navTheme = {
+  dark: false,
+  colors: {
+    primary: theme.colors.primary,
+    background: theme.colors.background,
+    card: theme.colors.card,
+    text: theme.colors.text,
+    border: theme.colors.border,
+    notification: theme.colors.primary,
+  },
+};
 

--- a/frontend/src/ui/Screen.js
+++ b/frontend/src/ui/Screen.js
@@ -1,2 +1,14 @@
-import React from 'react';import { View, StatusBar } from 'react-native';import { theme } from '../theme';
-export default function Screen({ children, style }){return(<View style={[{flex:1, backgroundColor:theme.colors.background, padding:16}, style]}><StatusBar barStyle="dark-content" />{children}</View>);}
+import React from 'react';
+import { View, StatusBar } from 'react-native';
+import { theme } from '../theme';
+
+export default function Screen({ children, style }) {
+  return (
+    <View
+      style={[{ flex: 1, backgroundColor: theme.colors.bg, padding: theme.pad }, style]}
+    >
+      <StatusBar barStyle="dark-content" />
+      {children}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add spacing and color utilities to theme and tidy Screen component
- redesign create post screen with card-based layout and creation options
- fix blank page after tapping Post by using defined theme helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6352ee27c8333ba87e42ce6bae8e8