### PR TITLE
Handle media replace/remove and video thumbnails

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "expo-auth-session": "^6.2.1",
     "expo-av": "~13.0.3",
     "expo-image-picker": "~15.0.6",
+    "expo-video-thumbnails": "~10.3.1",
     "expo-secure-store": "^14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- Prevent media preview from capturing remove/replace taps
- Generate thumbnails for picked videos and show enlarged video playback

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm test` (backend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b6527d05288333b6a75dce9953a86f