### PR TITLE
feat: add location picker to post creation

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -17,13 +17,19 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "Allow Community Microhelp to access your location"
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "permissions": [
+        "ACCESS_FINE_LOCATION"
+      ]
     },
     "web": {
       "bundler": "metro",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "expo-image-picker": "~15.0.6",
     "expo-video-thumbnails": "~10.3.1",
     "expo-secure-store": "^14.2.3",
+    "expo-location": "~17.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
@@ -31,6 +32,7 @@
     "react-native-safe-area-context": "^4.10.1",
     "react-native-screens": "~3.31.1",
     "react-native-web": "~0.19.10",
-    "expo-font": "~12.0.10"
+    "expo-font": "~12.0.10",
+    "react-native-maps": "1.10.0"
   }
 }

--- a/frontend/src/components/LocationPickerModal.js
+++ b/frontend/src/components/LocationPickerModal.js
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import Button from '../ui/Button';
+
+export default function LocationPickerModal({ visible, initialLocation, onSelect, onClose }) {
+  const [selected, setSelected] = useState(initialLocation);
+
+  useEffect(() => {
+    setSelected(initialLocation);
+  }, [initialLocation, visible]);
+
+  const initialRegion = initialLocation
+    ? { ...initialLocation, latitudeDelta: 0.01, longitudeDelta: 0.01 }
+    : {
+        latitude: 37.78825,
+        longitude: -122.4324,
+        latitudeDelta: 0.0922,
+        longitudeDelta: 0.0421,
+      };
+
+  const handleSelect = () => {
+    onSelect(selected);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <MapView
+        style={{ flex: 1 }}
+        initialRegion={initialRegion}
+        onPress={(e) => setSelected(e.nativeEvent.coordinate)}
+      >
+        {selected && <Marker coordinate={selected} />}
+      </MapView>
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 20,
+          left: 0,
+          right: 0,
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+        }}
+      >
+        <Button title="Cancel" onPress={onClose} style={{ flex: 1, marginHorizontal: 10 }} />
+        <Button title="Select" onPress={handleSelect} style={{ flex: 1, marginHorizontal: 10 }} />
+      </View>
+    </Modal>
+  );
+}

--- a/frontend/src/ui/Field.js
+++ b/frontend/src/ui/Field.js
@@ -1,3 +1,48 @@
-import React from 'react';import { View, Text, TextInput, StyleSheet } from 'react-native';import { theme } from '../theme';
-export default function Field({ label, value, onChangeText, placeholder, secureTextEntry=false, multiline=false }){return(<View style={{marginBottom: theme.spacing(1.5)}}>{label ? <Text style={styles.label}>{label}</Text> : null}<TextInput value={value} onChangeText={onChangeText} placeholder={placeholder} secureTextEntry={secureTextEntry} multiline={multiline} style={[styles.input, multiline ? {height:96, textAlignVertical:'top'} : null]} /></View>);}
-const styles=StyleSheet.create({label:{color:theme.colors.muted,marginBottom:6},input:{backgroundColor:'#fff',borderWidth:1,borderColor:theme.colors.border,borderRadius:theme.radius,paddingHorizontal:12,paddingVertical:10,color:theme.colors.text}});
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { theme } from '../theme';
+
+export default function Field({
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  secureTextEntry = false,
+  multiline = false,
+  editable = true,
+}) {
+  return (
+    <View style={{ marginBottom: theme.spacing(1.5) }}>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        secureTextEntry={secureTextEntry}
+        multiline={multiline}
+        editable={editable}
+        style={[
+          styles.input,
+          multiline ? { height: 96, textAlignVertical: 'top' } : null,
+          !editable ? { backgroundColor: theme.colors.border } : null,
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    color: theme.colors.muted,
+    marginBottom: 6,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: theme.colors.text,
+  },
+});


### PR DESCRIPTION
## Summary
- allow selecting current position or map-picked location when creating a post
- add modal with interactive map for choosing coordinates
- update field component and config for location support

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-location)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba18c468588333a199cab52dce75bf