### PR TITLE
Fix floating Post button and handle location on web

### DIFF
--- a/frontend/src/ui/FAB.js
+++ b/frontend/src/ui/FAB.js
@@ -1,13 +1,20 @@
 // src/ui/FAB.js
 import React from 'react';
-import { TouchableOpacity, Text, View } from 'react-native';
+import { TouchableOpacity, Text, View, Platform } from 'react-native';
 
 export default function FAB({ title = 'Post', onPress }) {
   return (
-    <View style={{
-      position: 'absolute', right: 16, bottom: 24,
-      shadowColor: '#000', shadowOpacity: 0.15, shadowRadius: 8, elevation: 6,
-    }}>
+    <View
+      style={{
+        position: Platform.OS === 'web' ? 'fixed' : 'absolute',
+        right: 16,
+        bottom: 24,
+        shadowColor: '#000',
+        shadowOpacity: 0.15,
+        shadowRadius: 8,
+        elevation: 6,
+      }}
+    >
       <TouchableOpacity
         onPress={onPress}
         style={{ backgroundColor: '#16A34A', borderRadius: 999, paddingVertical: 14, paddingHorizontal: 22 }}


### PR DESCRIPTION
## Summary
- keep Post button fixed to screen using platform-aware positioning
- guard current location flow with error handling and web fallbacks to prevent blank screen

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bca813dd208333b943f6d4036bf58d