### PR TITLE
Fix media auth for web and adjust FAB position

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -127,8 +127,10 @@ function signToken(payload) {
 async function requireAuth(req, res, next) {
   try {
     const header = req.headers.authorization;
-    if (!header) return res.status(401).json({ error: "Missing Authorization header" });
-    const [type, token] = header.split(" ");
+    const tokenFromQuery = typeof req.query.token === "string" ? req.query.token : null;
+    const raw = header || (tokenFromQuery ? `Bearer ${tokenFromQuery}` : null);
+    if (!raw) return res.status(401).json({ error: "Missing Authorization header" });
+    const [type, token] = raw.split(" ");
     if (type !== "Bearer" || !token) return res.status(401).json({ error: "Invalid Authorization header" });
     const decoded = jwt.verify(token, JWT_SECRET);
     req.user = decoded;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,4 +1,5 @@
 // src/api/index.js
+import { Platform } from 'react-native';
 import { apiGet, apiPost, apiPatch, apiDelete, apiUploadPost } from './apiClient';
 import { BASE_URL } from '../config';
 import { getTokens } from './tokenStore';
@@ -75,6 +76,16 @@ export async function imageSource(pathOrUrl) {
   const url = pathOrUrl?.startsWith('http') ? pathOrUrl : `${BASE_URL}${pathOrUrl}`;
   const tokens = await getTokens();
   const token = tokens?.accessToken;
+
+  // React Native Web's <Image> does not support custom headers, so embed the
+  // token as a query param for browser builds while keeping header-based auth
+  // for native platforms.
+  if (Platform.OS === 'web' && token) {
+    const u = new URL(url);
+    u.searchParams.set('token', token);
+    return { uri: u.toString() };
+  }
+
   return token
     ? { uri: url, headers: { Authorization: `Bearer ${token}` } }
     : { uri: url };

--- a/frontend/src/ui/FAB.js
+++ b/frontend/src/ui/FAB.js
@@ -8,7 +8,7 @@ export default function FAB({ title = 'Post', onPress }) {
       style={{
         position: Platform.OS === 'web' ? 'fixed' : 'absolute',
         right: 16,
-        bottom: 24,
+        bottom: 64,
         shadowColor: '#000',
         shadowOpacity: 0.15,
         shadowRadius: 8,


### PR DESCRIPTION
## Summary
- allow token query authentication for media requests and embed tokens in image URLs on web so feed attachments display
- raise the floating action button higher on the feed screen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f10fb224883339a85d360d1c252a7)