### PR TITLE
Fix media attachment URLs for posts

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -828,12 +828,14 @@ async function start() {
       }
 
       const files = req.files || [];
+      const baseUrl = process.env.PUBLIC_BASE_URL || `${req.protocol}://${req.get("host")}`;
+
       const attachments = files.map(f => {
         const name = path.basename(f.path);
         return {
           filename: f.originalname,
           path: `/uploads/${name}`,
-          absoluteUrl: `${PUBLIC_BASE_URL}/uploads/${name}`,
+          absoluteUrl: `${baseUrl}/uploads/${name}`,
           size: f.size,
           mimetype: f.mimetype,
         };

--- a/frontend/src/components/PostCard.js
+++ b/frontend/src/components/PostCard.js
@@ -18,7 +18,7 @@ export default function PostCard({ post, onLike, onComment, onShare, onPress }) 
         const list = await Promise.all(
           attachments.map(async (a) => ({
             type: a.mimetype?.startsWith('video') ? 'video' : 'image',
-            source: await imageSource(a.absoluteUrl || a.url || a.path),
+            source: await imageSource(a.path || a.url || a.absoluteUrl),
           }))
         );
         const safeList = list.filter((item) => item?.source);

--- a/frontend/src/screens/posts/PostDetailScreen.js
+++ b/frontend/src/screens/posts/PostDetailScreen.js
@@ -23,7 +23,7 @@ export default function PostDetailScreen({ route }) {
         const list = await Promise.all(
           attachments.map(async (a) => ({
             type: a.mimetype?.startsWith('video') ? 'video' : 'image',
-            source: await imageSource(a.absoluteUrl || a.url || a.path),
+            source: await imageSource(a.path || a.url || a.absoluteUrl),
           }))
         );
         setMedia(list.filter((item) => item?.source));


### PR DESCRIPTION
## Summary
- use request host or configured PUBLIC_BASE_URL when building attachment URLs during post creation
- prefer relative upload paths on the frontend when loading post media so the client base URL is applied

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb1db12688333bdde4271dce4abfb)